### PR TITLE
README.md as a Bash notebook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ install:
 script:
   - # Test the (Python) notebook in the current Python environment
   - jupytext world_facts.md --set-kernel - --execute
+  - # Test the (Bash) README
+  - python -m bash_kernel.install
+  - jupytext README.md --execute

--- a/README.md
+++ b/README.md
@@ -4,3 +4,30 @@
 This repository contains Material for CFM's Jupytext+Papermill blog post (Sep. 2019).
 
 Before the publication of the blog post, this is a work in progress.
+
+# Bash commands
+
+```bash
+jupytext world_facts.md --to ipynb
+```
+
+```bash
+jupytext world_facts.ipynb --set-kernel -
+```
+
+
+```bash
+papermill world_facts.ipynb world_facts_2017.ipynb -p year 2017
+```
+
+```bash
+jupyter nbconvert world_facts_2017.ipynb --to html
+```
+
+```bash
+jupyter nbconvert --to html --no-input world_facts_2017.ipynb --output world_facts_2017_report.html
+```
+
+```bash
+cat world_facts.md | jupytext --from md --to ipynb --set-kernel - | papermill -p year 2017 | jupyter nbconvert --stdin --output world_facts_2017_report.html
+```

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+# Install the bash kernel
+python -m bash_kernel.install

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ nbconvert
 
 # TOC extension for Binder
 jupyter_contrib_nbextensions
+
+# README.md as a Bash notebook
+bash_kernel


### PR DESCRIPTION
- Execute `README.md` as a Bash notebook on Travis
- Open `README.md` as a Bash notebook on Binder